### PR TITLE
App Service Plan can be in a different ResourceGroup to the App Service

### DIFF
--- a/SampleJsonConfig/appproperties.json
+++ b/SampleJsonConfig/appproperties.json
@@ -39,5 +39,13 @@
     "IsFunctionApp": true,
     "IsSlot": true,
     "SlotName": "SLOT_NAME"
+  },
+  {
+    "Hostname": "SUB.YOUR_DOMAIN.EXT",
+    "ResourceName": "WEBAPP_RESOURCE_NAME",
+    "ResourceResGroup": "RESOURCE_GROUP_CONTAINING_THE_WEBAPP",
+    "ResourcePlanResGroup": "RESOURCE_GROUP_CONTAINING_THE_APPSERVICEPLAN", //For when the AppService belongs to an AppServicePlan in a different ResourceGroup (works for all types of resource and certificate)
+    "AzureDnsZoneName": "DNS_RESOURCE_NAME",
+    "AzureDnsResGroup": "RESOURCE_GROUP_CONTAINING_THE_DNS"
   }
 ] 

--- a/src/WebAppSSLManager/AzureHelper.cs
+++ b/src/WebAppSSLManager/AzureHelper.cs
@@ -24,6 +24,7 @@ namespace WebAppSSLManager
         private static string _dnsResGroup;
         private static string _resourceName;
         private static string _resourceResGroup;
+        private static string _resourcePlanResGroup;
         private static string _hostname;
         private static string _hostnameFriendly;
         private static string _pfxFileName;
@@ -61,6 +62,7 @@ namespace WebAppSSLManager
             _dnsResGroup = appProperty.AzureDnsResGroup.Trim();
             _resourceName = appProperty.ResourceName.Trim();
             _resourceResGroup = appProperty.ResourceResGroup.Trim();
+            _resourcePlanResGroup = appProperty.PlanResourceGroup.Trim();
             _hostname = appProperty.Hostname.Trim();
             _hostnameFriendly = appProperty.HostnameFriendly;
             _pfxFileName = appProperty.PfxFileName;
@@ -184,7 +186,7 @@ namespace WebAppSSLManager
             //Retrieving old certificate, if any
             _logger.LogInformation($"   Retrieving old certificate, if any");
 
-            var oldCertificates = _azure.AppServices.AppServiceCertificates.ListByResourceGroup(_resourceResGroup).Where(c => c.HostNames.Contains(_hostname));
+            var oldCertificates = _azure.AppServices.AppServiceCertificates.ListByResourceGroup(_resourcePlanResGroup).Where(c => c.HostNames.Contains(_hostname));
             _logger.LogInformation($"   Found {oldCertificates.Count()}");
 
             _logger.LogInformation($"   Uploading Certificate");
@@ -194,7 +196,7 @@ namespace WebAppSSLManager
             var certificate = await _azure.AppServices.AppServiceCertificates
                                         .Define($"{_hostname}_{DateTime.UtcNow.ToString("yyyyMMdd")}")
                                         .WithRegion(region)
-                                        .WithExistingResourceGroup(_resourceResGroup)
+                                        .WithExistingResourceGroup(_resourcePlanResGroup)
                                         .WithPfxByteArray(pfxByteArrayContent)
                                         .WithPfxPassword(Settings.CertificatePassword)
                                         .CreateAsync();

--- a/src/WebAppSSLManager/Models/AppProperty.cs
+++ b/src/WebAppSSLManager/Models/AppProperty.cs
@@ -8,6 +8,7 @@ namespace WebAppSSLManager.Models
         public string Hostname { get; set; }
         public string ResourceName { get; set; } //either the WebApp name or the FunctionApp name
         public string ResourceResGroup { get; set; } //the resource group container the WebApp or the FunctionApp
+        public string ResourcePlanResGroup { get; set; }
         public string AzureDnsZoneName { get; set; }
         public string AzureDnsResGroup { get; set; }
 
@@ -21,6 +22,8 @@ namespace WebAppSSLManager.Models
         //Others
         public string HostnameFriendly
             => Hostname.Trim().Replace("*.", "");
+
+        public string PlanResourceGroup => ResourcePlanResGroup ?? ResourceResGroup;
 
         public string BaseDomain
         {

--- a/src/WebAppSSLManager/Models/AppProperty.cs
+++ b/src/WebAppSSLManager/Models/AppProperty.cs
@@ -8,7 +8,7 @@ namespace WebAppSSLManager.Models
         public string Hostname { get; set; }
         public string ResourceName { get; set; } //either the WebApp name or the FunctionApp name
         public string ResourceResGroup { get; set; } //the resource group container the WebApp or the FunctionApp
-        public string ResourcePlanResGroup { get; set; }
+        public string ResourcePlanResGroup { get; set; } //(optional) If the AppServicePlan is in a different resource group, this is the name of the Plan's resource group
         public string AzureDnsZoneName { get; set; }
         public string AzureDnsResGroup { get; set; }
 
@@ -25,7 +25,7 @@ namespace WebAppSSLManager.Models
 
         public string BaseDomain => AzureDnsZoneName;
   
-        public string PlanResourceGroup => ResourcePlanResGroup ?? ResourceResGroup;
+        public string PlanResourceGroup => ResourcePlanResGroup ?? ResourceResGroup; // Use the resource group of the AppService or FunctionApp if it has not explictly been set for the AppServicePlan
         
         public string PfxFileName
             => $"{HostnameFriendly}.pfx";


### PR DESCRIPTION
This pull request adds support for optionally specifying the ResourceGroup that the App Service Plan is in so that we can upload certificates to plans that are in different resource groups to their app services.

e.g.
```
{
    "Hostname": "www.domain.com", 
    "ResourceName": "WebApp",
    "ResourceResGroup": "RG1",
    "ResourcePlanResGroup": "RG2",
    "AzureDnsZoneName": "domain.com",
    "AzureDnsResGroup": "RG-DOMAIN"
  },
```