### PR TITLE
Fix attempting to apply wildcards to the wrong hostnames

### DIFF
--- a/src/WebAppSSLManager/AzureHelper.cs
+++ b/src/WebAppSSLManager/AzureHelper.cs
@@ -179,7 +179,7 @@ namespace WebAppSSLManager
             }
 
             if (_hostname.StartsWith("*."))
-                hostnamesList.AddRange(hostnamesInternal.Where(h => h.Contains(_hostnameFriendly)));
+                hostnamesList.AddRange(hostnamesInternal.Where(h => h.EndsWith($".{_hostnameFriendly}")));
             else
                 hostnamesList.Add(_hostname);
 


### PR DESCRIPTION
When generating wildcard certificates we were attempting to apply them to anything that contained the fragment after the wildcard.  This causes error if the hostname doesn't match the wildcard.

Examples:

`*.domain.com` being applied to `domain.com` (*. doesn't apply to naked domain)

`*.example.com` being applied to `example.com.hosted.at.host.com` (due to `Contains()` rather than `EndsWith()`)