### PR TITLE
Solution for functions timeout preventing all certificates being renewed

### DIFF
--- a/ARM Template/parameters - sample.json
+++ b/ARM Template/parameters - sample.json
@@ -34,6 +34,15 @@
         },
         "useStaging": {
             "value": "False"
-        }
+        },
+		"BatchSize": {
+			"value": "0"
+		},
+		"TimeBeforeExpiryToRenew": {
+			"value": "30.00:00:00"
+		},
+		"WebAppSSLManager-Trigger": {
+			"value": "0 0 0 * * *"
+		}
     }
 }

--- a/ARM Template/template.json
+++ b/ARM Template/template.json
@@ -34,7 +34,19 @@
         },
         "useStaging": {
             "type": "string"
-        }
+        },
+		"batchSize": {
+			"type": "string",
+			"defaultValue": "0"
+		},
+		"timeBeforeExpiryToRenew": {
+			"type": "string",
+			"defaultValue": "30.00:00:00"
+		},
+		"WebAppSSLManager-Trigger": {
+			"type": "string",
+			"defaultValue": "0 0 0 * * *"
+		}
     },
     "variables": {  
         "location": "[resourceGroup().location]",
@@ -172,6 +184,18 @@
                         {
                             "name": "UseStaging",
                             "value": "[parameters('useStaging')]"
+                        },
+                        {
+                            "name": "BatchSize",
+                            "value": "[parameters('batchSize')]"
+                        },
+                        {
+                            "name": "TimeBeforeExpiryToRenew",
+                            "value": "[parameters('timeBeforeExpiryToRenew')]"
+                        },
+                        {
+                            "name": "WebAppSSLManager-Trigger",
+                            "value": "[parameters('webAppSSLManager-Trigger')]"
                         }
                     ]
                 },

--- a/README.md
+++ b/README.md
@@ -110,10 +110,16 @@ They can be created in the Azure Web App configuration section when deployed, or
     "AzureStorageAccountConnectionString": "AZURE_STORAGE_FULL_CONNECTION_STRING",
     "SendGridKey": "SENDGRID_KEY",
     "EmailSender": "SENDER@YOURSERVICE.EXT",
-    "UseStaging": "[True|False]"
+    "UseStaging": "[True|False]",
+	"BatchSize": [<0 for no batching> | <int>],
+	"TimeBeforeExpiryToRenew": "days.hours:minutes:seconds"
 ```
 
 The config settings for the Service Principal are the ones from the output of the Service Principal creation above.
+
+BatchSize is optional and defaults to 0.
+
+TimeBeforeExpiryToRenew is optional and defaults to "30.00:00:00" (renew certificates 30 days before they expire).
 
 ## Application Properties Configuration File
 

--- a/src/WebAppSSLManager/AzureHelper.cs
+++ b/src/WebAppSSLManager/AzureHelper.cs
@@ -129,65 +129,44 @@ namespace WebAppSSLManager
         }
 
         /// <summary>
+        /// Checks whether the Azure resource needs a new certificate
+        /// </summary>
+        /// <returns>True if a new certificate should be requested</returns>
+        public static async Task<bool> NeedsNewCertificateAsync()
+        {
+            ResourceConfiguration resource = await GetResourceConfigurationAsync();
+
+            IAppServiceCertificate existingCert = resource.ExistingCertificates?
+                                                            .Where(c => c.Issuer.Contains("Let's Encrypt Authority"))
+                                                            .OrderByDescending(c => c.ExpirationDate)
+                                                            .FirstOrDefault();
+            
+            if(existingCert == null)
+            {
+                return true;
+            }
+
+            TimeSpan timeUntilExpiry = existingCert.ExpirationDate - DateTime.Now;
+
+            if(timeUntilExpiry < Settings.TimeBeforeExpiryToRenew)
+            {
+                return true;
+            }
+            
+            _logger.LogInformation($"   Existing certificate with thumbprint {existingCert.Thumbprint} is not close to expiry.  A new certificate is not required.");
+
+            return false;
+        }
+        
+        /// <summary>
         /// Add the certificate to the resource on Azure
         /// </summary>
         /// <returns></returns>
         public static async Task AddCertificateAsync()
         {
             _logger.LogInformation($"Adding certificate to App Service and registering the Bindings");
-
-            ISet<string> hostnamesInternal;
-            var hostnamesList = new List<string>();
-            Region region;
-            IResource resource;
-
-            switch (_resourceType)
-            {
-                case ResourceType.WebAppSlot:
-                    var slot = await _azure.WebApps.ListByResourceGroup(_resourceResGroup).Where(w => w.Name.Equals(_resourceName, StringComparison.CurrentCultureIgnoreCase)).SingleOrDefault().DeploymentSlots.GetByNameAsync(_slotName);
-                    hostnamesInternal = slot.HostNames;
-
-                    region = slot.Region;
-                    resource = slot;
-
-                    break;
-                case ResourceType.FunctionApp:
-                    var functionApp = _azure.AppServices.FunctionApps.ListByResourceGroup(_resourceResGroup).Where(fa => fa.Name.Equals(_resourceName, StringComparison.CurrentCultureIgnoreCase)).SingleOrDefault();
-                    hostnamesInternal = functionApp.HostNames;
-
-                    region = functionApp.Region;
-                    resource = functionApp;
-
-                    break;
-                case ResourceType.FunctionAppSlot:
-                    var functionAppSlot = await _azure.AppServices.FunctionApps.ListByResourceGroup(_resourceResGroup).Where(fa => fa.Name.Equals(_resourceName, StringComparison.CurrentCultureIgnoreCase)).SingleOrDefault().DeploymentSlots.GetByNameAsync(_slotName);
-                    hostnamesInternal = functionAppSlot.HostNames;
-
-                    region = functionAppSlot.Region;
-                    resource = functionAppSlot;
-
-                    break;
-                case ResourceType.WebApp:
-                default:
-                    var webApp = _azure.WebApps.ListByResourceGroup(_resourceResGroup).Where(w => w.Name.Equals(_resourceName, StringComparison.CurrentCultureIgnoreCase)).SingleOrDefault();
-                    hostnamesInternal = webApp.HostNames;
-
-                    region = webApp.Region;
-                    resource = webApp;
-
-                    break;
-            }
-
-            if (_hostname.StartsWith("*."))
-                hostnamesList.AddRange(hostnamesInternal.Where(h => h.Contains(_hostnameFriendly)));
-            else
-                hostnamesList.Add(_hostname);
-
-            //Retrieving old certificate, if any
-            _logger.LogInformation($"   Retrieving old certificate, if any");
-
-            var oldCertificates = _azure.AppServices.AppServiceCertificates.ListByResourceGroup(_resourcePlanResGroup).Where(c => c.HostNames.Contains(_hostname));
-            _logger.LogInformation($"   Found {oldCertificates.Count()}");
+            
+            var resource = await GetResourceConfigurationAsync();
 
             _logger.LogInformation($"   Uploading Certificate");
 
@@ -195,7 +174,7 @@ namespace WebAppSSLManager
 
             var certificate = await _azure.AppServices.AppServiceCertificates
                                         .Define($"{_hostname}_{DateTime.UtcNow.ToString("yyyyMMdd")}")
-                                        .WithRegion(region)
+                                        .WithRegion(resource.Region)
                                         .WithExistingResourceGroup(_resourcePlanResGroup)
                                         .WithPfxByteArray(pfxByteArrayContent)
                                         .WithPfxPassword(Settings.CertificatePassword)
@@ -203,16 +182,16 @@ namespace WebAppSSLManager
 
             var certificateThumbPrint = certificate.Thumbprint;
             _logger.LogInformation($"   Certificate Uploaded");
-            _logger.LogInformation($"   Bindings to process: {hostnamesList.Count}");
+            _logger.LogInformation($"   Bindings to process: {resource.Hostnames.Count}");
 
-            foreach (var hostname in hostnamesList)
+            foreach (var hostname in resource.Hostnames)
             {
                 try
                 {
                     switch (_resourceType)
                     {
                         case ResourceType.WebAppSlot:
-                            var slot = resource as IDeploymentSlot;
+                            var slot = resource.Resource as IDeploymentSlot;
                             _logger.LogInformation($"       Updating '{hostname}' on WebApp Slot '{slot.Name}'");
 
                             slot = await slot
@@ -225,7 +204,7 @@ namespace WebAppSSLManager
                                     .ApplyAsync();
                             break;
                         case ResourceType.FunctionApp:
-                            var functionApp = resource as IFunctionApp;
+                            var functionApp = resource.Resource as IFunctionApp;
                             _logger.LogInformation($"       Updating '{hostname}' on FunctionApp '{functionApp.Name}'");
 
                             functionApp = await functionApp
@@ -238,7 +217,7 @@ namespace WebAppSSLManager
                                             .ApplyAsync();
                             break;
                         case ResourceType.FunctionAppSlot:
-                            var functionAppSlot = resource as IFunctionDeploymentSlot;
+                            var functionAppSlot = resource.Resource as IFunctionDeploymentSlot;
                             _logger.LogInformation($"       Updating '{hostname}' on FunctionApp Slot '{functionAppSlot.Name}'");
 
                             functionAppSlot = await functionAppSlot
@@ -252,7 +231,7 @@ namespace WebAppSSLManager
                             break;
                         case ResourceType.WebApp:
                         default:
-                            var webApp = resource as IWebApp;
+                            var webApp = resource.Resource as IWebApp;
                             _logger.LogInformation($"       Updating '{hostname}' on WebApp '{webApp.Name}'");
 
                             webApp = await webApp
@@ -286,11 +265,11 @@ namespace WebAppSSLManager
             }
             _logger.LogInformation($"   All bindings processed and secured with SSL");
 
-            if (oldCertificates.Any())
+            if (resource.ExistingCertificates.Any())
             {
                 _logger.LogInformation($"   Removing old certificates");
 
-                foreach (var oldCert in oldCertificates)
+                foreach (var oldCert in resource.ExistingCertificates)
                 {
                     if (oldCert.Thumbprint != certificate.Thumbprint)
                     {
@@ -355,6 +334,62 @@ namespace WebAppSSLManager
             _blobContainer = null;
             _blobClient = null;
             _azure = null;
+        }
+
+        private static async Task<ResourceConfiguration> GetResourceConfigurationAsync()
+        {
+            var config = new ResourceConfiguration();
+            ISet<string> hostnamesInternal;
+
+            switch (_resourceType)
+            {
+                case ResourceType.WebAppSlot:
+                    var slot = await _azure.WebApps.ListByResourceGroup(_resourceResGroup).Where(w => w.Name.Equals(_resourceName, StringComparison.CurrentCultureIgnoreCase)).SingleOrDefault().DeploymentSlots.GetByNameAsync(_slotName);
+                    hostnamesInternal = slot.HostNames;
+
+                    config.Region = slot.Region;
+                    config.Resource = slot;
+
+                    break;
+                case ResourceType.FunctionApp:
+                    var functionApp = _azure.AppServices.FunctionApps.ListByResourceGroup(_resourceResGroup).Where(fa => fa.Name.Equals(_resourceName, StringComparison.CurrentCultureIgnoreCase)).SingleOrDefault();
+                    hostnamesInternal = functionApp.HostNames;
+
+                    config.Region = functionApp.Region;
+                    config.Resource = functionApp;
+
+                    break;
+                case ResourceType.FunctionAppSlot:
+                    var functionAppSlot = await _azure.AppServices.FunctionApps.ListByResourceGroup(_resourceResGroup).Where(fa => fa.Name.Equals(_resourceName, StringComparison.CurrentCultureIgnoreCase)).SingleOrDefault().DeploymentSlots.GetByNameAsync(_slotName);
+                    hostnamesInternal = functionAppSlot.HostNames;
+
+                    config.Region = functionAppSlot.Region;
+                    config.Resource = functionAppSlot;
+
+                    break;
+                case ResourceType.WebApp:
+                default:
+                    var webApp = _azure.WebApps.ListByResourceGroup(_resourceResGroup).Where(w => w.Name.Equals(_resourceName, StringComparison.CurrentCultureIgnoreCase)).SingleOrDefault();
+                    hostnamesInternal = webApp.HostNames;
+
+                    config.Region = webApp.Region;
+                    config.Resource = webApp;
+
+                    break;
+            }
+
+            if (_hostname.StartsWith("*."))
+                config.Hostnames.AddRange(hostnamesInternal.Where(h => h.Contains(_hostnameFriendly)));
+            else
+                config.Hostnames.Add(_hostname);
+
+            //Retrieving old certificate, if any
+            _logger.LogInformation($"   Retrieving old certificate, if any");
+
+            config.ExistingCertificates = _azure.AppServices.AppServiceCertificates.ListByResourceGroup(_resourcePlanResGroup).Where(c => c.HostNames.Contains(_hostname)).ToList();
+            _logger.LogInformation($"   Found {config.ExistingCertificates.Count()}");
+
+            return config;
         }
     }
 }

--- a/src/WebAppSSLManager/Models/Constants.cs
+++ b/src/WebAppSSLManager/Models/Constants.cs
@@ -1,4 +1,6 @@
-﻿namespace WebAppSSLManager.Models
+﻿using System;
+
+namespace WebAppSSLManager.Models
 {
     public class Constants
     {
@@ -8,5 +10,7 @@
         public const string DefaultCertificatePassword = "C0mpl1c4t3d57r1ng";
         public const string CertificateBlobContainer = "certificates";
         public const string DefaultEmailSender = "AzureWebAppSSLManager@dbtek.com.hk";
+        public const int DefaultBatchSize = 0;
+        public static readonly TimeSpan DefaultTimeBeforeExpiryToRenewCertificate = TimeSpan.FromDays(30);
     }
 }

--- a/src/WebAppSSLManager/Models/Settings.cs
+++ b/src/WebAppSSLManager/Models/Settings.cs
@@ -16,6 +16,8 @@ namespace WebAppSSLManager.Models
         public static string CertificatePassword { get; private set; }
         public static string EmailSender { get; private set; }
         public static bool UseStaging { get; private set; }
+        public static int BatchSize { get; private set; }
+        public static TimeSpan TimeBeforeExpiryToRenew { get; private set; }
 
         public static void Init(ILogger logger)
         {
@@ -77,8 +79,28 @@ namespace WebAppSSLManager.Models
                 EmailSender = Constants.DefaultEmailSender;
             }
 
+            if(int.TryParse(Environment.GetEnvironmentVariable("BatchSize"), out int batchSize) && batchSize >= 0)
+            {
+                BatchSize = batchSize;
+            }
+            else
+            {
+                _logger.LogWarning("BatchSize environment variable is null or invalid. Reverting to default");
+                BatchSize = Constants.DefaultBatchSize;
+            }
+
             bool.TryParse(Environment.GetEnvironmentVariable("UseStaging"), out var useStaging);
             UseStaging = useStaging;
+
+            if (TimeSpan.TryParse(Environment.GetEnvironmentVariable("TimeBeforeExpiryToRenew"), out TimeSpan renewTime) && renewTime.TotalDays < 90 && renewTime.TotalDays > 0)
+            {
+                TimeBeforeExpiryToRenew = renewTime;
+            }
+            else
+            {
+                _logger.LogWarning("TimeBeforeExpiryToRenew environment variable is null or invalid. Reverting to default");
+                TimeBeforeExpiryToRenew = Constants.DefaultTimeBeforeExpiryToRenewCertificate;
+            }
         }
     }
 }

--- a/src/WebAppSSLManager/ResourceConfiguration.cs
+++ b/src/WebAppSSLManager/ResourceConfiguration.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using Microsoft.Azure.Management.AppService.Fluent;
+using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
+
+namespace WebAppSSLManager
+{
+    public class ResourceConfiguration
+    {
+        public List<string> Hostnames { get; } = new List<string>();
+        public Region Region { get; set; }
+        public IResource Resource { get; set; }
+        public List<IAppServiceCertificate> ExistingCertificates { get; set; }
+    }
+}


### PR DESCRIPTION
### When using Azure Functions on the Consumption Plan
By default, functions running with a Consumption Plan are terminated if they run for longer than five minutes.  This can be extended to 10 minutes in the host.json, but for anyone who deployed via the ARM template this file is read-only.

When you have a large number of certificates to renew, it is likely that the function will be terminated before it can finish.

### Solution
The solution for this problem is threefold:
1. Configure the function to only request a new certificate if the existing one is due to expire soon (in 30 days by default, but configurable).
2. Configure the function to exit once it has generated a certain number of certificates (batch size, defaults to 0/unlimited, but configurable).
3. Schedule the function to run more frequently (once per day?) and allow this schedule to be configured.

