### PR TITLE
Find existing certs issued by the new Lets Encrypt Intermediate "R3" 

### DIFF
--- a/src/WebAppSSLManager/AzureHelper.cs
+++ b/src/WebAppSSLManager/AzureHelper.cs
@@ -137,12 +137,16 @@ namespace WebAppSSLManager
             ResourceConfiguration resource = await GetResourceConfigurationAsync();
 
             IAppServiceCertificate existingCert = resource.ExistingCertificates?
-                                                            .Where(c => c.Issuer.Contains(Constants.DefaultCA))
+                                                            .Where(c => c.Issuer.Contains(Constants.DefaultCA) || c.Issuer.Equals(Constants.DefaultIntermediate))
                                                             .OrderByDescending(c => c.ExpirationDate)
                                                             .FirstOrDefault();
-            
-            if(existingCert == null)
+
+            if (existingCert == null)
+            {
+                _logger.LogInformation("   No existing certificate found.");
+
                 return true;
+            }
 
             TimeSpan timeUntilExpiry = existingCert.ExpirationDate - DateTime.Now;
 

--- a/src/WebAppSSLManager/Models/Constants.cs
+++ b/src/WebAppSSLManager/Models/Constants.cs
@@ -11,6 +11,7 @@ namespace WebAppSSLManager.Models
         public const string CertificateBlobContainer = "certificates";
         public const string DefaultEmailSender = "AzureWebAppSSLManager@dbtek.com.hk";
         public const string DefaultCA = "Let's Encrypt Authority";
+        public const string DefaultIntermediate = "R3";
         public const int DefaultBatchSize = 0;
         public const int DaysBeforeExpiryToRenew = 30;
     }


### PR DESCRIPTION
Add support for certificates generated by the new LetsEncrypt Intermediate Authority "R3".

See https://community.letsencrypt.org/t/beginning-issuance-from-r3/139018/3 for more details.

(Without this change we end up requesting a new certificate every time the function runs as it doesn't find the existing one)