### PR TITLE
Add 'wait time before validate' after creating dns record

### DIFF
--- a/src/WebAppSSLManager/AzureHelper.cs
+++ b/src/WebAppSSLManager/AzureHelper.cs
@@ -384,10 +384,10 @@ namespace WebAppSSLManager
                 config.Hostnames.Add(_hostname);
 
             //Retrieving old certificate, if any
-            _logger.LogInformation($"   Retrieving old certificate, if any");
+            _logger.LogInformation($"   Retrieving old certificate for {_hostname}, if any");
 
             config.ExistingCertificates = _azure.AppServices.AppServiceCertificates.ListByResourceGroup(_resourcePlanResGroup).Where(c => c.HostNames.Contains(_hostname)).ToList();
-            _logger.LogInformation($"   Found {config.ExistingCertificates.Count()}");
+            _logger.LogInformation($"   Found {config.ExistingCertificates.Count}");
 
             return config;
         }

--- a/src/WebAppSSLManager/CertificatesHelper.cs
+++ b/src/WebAppSSLManager/CertificatesHelper.cs
@@ -125,6 +125,9 @@ namespace WebAppSSLManager
             await AzureHelper.RemoveDNSVerificationTXTRecord(recordName); //to be sure we start clean
             await AzureHelper.CreateDNSVerificationTXTRecord(recordName, dnsTxt);
 
+            _logger.LogInformation($"   Waiting before validating DNS authorization challenge...");
+            Thread.Sleep(Settings.WaitTimeBeforeValidate);
+
             _logger.LogInformation($"   Validating DNS authorization challenge. Can take up to 90 seconds...");
             var validatedChallege = await dnsChallenge.Validate();
             var waitUntil = DateTime.Now.AddSeconds(90);

--- a/src/WebAppSSLManager/CertificatesHelper.cs
+++ b/src/WebAppSSLManager/CertificatesHelper.cs
@@ -126,7 +126,7 @@ namespace WebAppSSLManager
             await AzureHelper.CreateDNSVerificationTXTRecord(recordName, dnsTxt);
 
             _logger.LogInformation($"   Waiting {Settings.WaitTimeBeforeValidate.TotalSeconds} seconds before validating DNS authorization challenge...");
-            await Task.Delay(Settings.WaitTimeBeforeValidate.TotalMilliseconds);
+            await Task.Delay(Settings.WaitTimeBeforeValidate);
 
             _logger.LogInformation($"   Validating DNS authorization challenge. Can take up to 90 seconds...");
             var validatedChallege = await dnsChallenge.Validate();

--- a/src/WebAppSSLManager/CertificatesHelper.cs
+++ b/src/WebAppSSLManager/CertificatesHelper.cs
@@ -125,8 +125,8 @@ namespace WebAppSSLManager
             await AzureHelper.RemoveDNSVerificationTXTRecord(recordName); //to be sure we start clean
             await AzureHelper.CreateDNSVerificationTXTRecord(recordName, dnsTxt);
 
-            _logger.LogInformation($"   Waiting before validating DNS authorization challenge...");
-            Thread.Sleep(Settings.WaitTimeBeforeValidate);
+            _logger.LogInformation($"   Waiting {Settings.WaitTimeBeforeValidate.TotalSeconds} seconds before validating DNS authorization challenge...");
+            await Task.Delay(Settings.WaitTimeBeforeValidate.TotalMilliseconds);
 
             _logger.LogInformation($"   Validating DNS authorization challenge. Can take up to 90 seconds...");
             var validatedChallege = await dnsChallenge.Validate();

--- a/src/WebAppSSLManager/Models/Constants.cs
+++ b/src/WebAppSSLManager/Models/Constants.cs
@@ -14,5 +14,6 @@ namespace WebAppSSLManager.Models
         public const string DefaultIntermediate = "R3";
         public const int DefaultBatchSize = 0;
         public const int DaysBeforeExpiryToRenew = 30;
+        public static readonly TimeSpan WaitTimeBeforeValidate = TimeSpan.FromSeconds(10);
     }
 }

--- a/src/WebAppSSLManager/Models/Settings.cs
+++ b/src/WebAppSSLManager/Models/Settings.cs
@@ -19,6 +19,7 @@ namespace WebAppSSLManager.Models
         public static int BatchSize { get; private set; }
         public static int DaysBeforeExpiryToRenew { get; private set; }
         public static TimeSpan TimeBeforeExpiryToRenew { get; private set; }
+        public static TimeSpan WaitTimeBeforeValidate { get; private set; }
 
         public static void Init(ILogger logger)
         {
@@ -100,6 +101,14 @@ namespace WebAppSSLManager.Models
             }
 
             TimeBeforeExpiryToRenew = TimeSpan.FromDays(DaysBeforeExpiryToRenew);
+
+            if (int.TryParse(Environment.GetEnvironmentVariable("WaitTimeBeforeValidateInSeconds"), out int seconds) && seconds >= 0)
+                WaitTimeBeforeValidate = TimeSpan.FromSeconds(seconds);
+            else
+            {
+                _logger.LogWarning("WaitTimeBeforeValidateInSeconds environment variable is null or invalid. Reverting to default");
+                WaitTimeBeforeValidate = Constants.WaitTimeBeforeValidate;
+            }
         }
     }
 }


### PR DESCRIPTION
At out company we had some issues that the certificates were no longer renewed. 
After some trail and error I reduced the problem to creating the TXT record and LetsEncrypt using this value.
Without any delay the you will receive an AcmeException from the Validate function. Because of the exception the retry logic 90 seconds does not work either.

